### PR TITLE
Use shared maintenance workflows

### DIFF
--- a/.github/workflows/protect-readme.yml
+++ b/.github/workflows/protect-readme.yml
@@ -7,33 +7,4 @@ on:
 
 jobs:
   check-readme:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Block direct README edits
-        if: github.event.pull_request.user.type != 'Bot'
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const files = await github.paginate(github.rest.pulls.listFiles, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-              per_page: 100,
-            });
-
-            const hasSourceChanges = files.some(f =>
-              f.filename === 'awesome-list.yaml' ||
-              f.filename.startsWith('data/') ||
-              f.filename.startsWith('scripts/') ||
-              f.filename.startsWith('schema/')
-            );
-
-            if (!hasSourceChanges) {
-              core.setFailed(
-                'README.md must not be edited directly.\n\n' +
-                'This repository uses a data-first workflow and auto-generates README.md from YAML files.\n\n' +
-                'To suggest a new resource, open an issue instead:\n' +
-                `https://github.com/${context.repo.owner}/${context.repo.repo}/issues/new/choose`
-              );
-            }
-
+    uses: jslee02/awesome-list-infra/.github/workflows/protect-readme.yml@main


### PR DESCRIPTION
## Summary
- Replace copied README-protection workflow logic with the shared reusable workflow
- Add scheduled metadata refresh workflow where the repo already has `scripts/fetch_metadata.py`
- Keep metadata refresh jobs staggered across the week to avoid unnecessary API bursts

## Validation
- Parsed all updated workflow YAML with PyYAML
- `git diff --check`
